### PR TITLE
adds in product schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,144 @@
-# ExCosmic
+# Cosmic Lounge
 
-To start your Phoenix server:
+E-commerce sites are pretty complicated, but when you get to the core functionality, they really only do a few things:
 
-  * Install dependencies with `mix deps.get`
-  * Create and migrate your database with `mix ecto.setup`
-  * Install Node.js dependencies with `npm install` inside the `assets` directory
-  * Start Phoenix endpoint with `mix phx.server`
+1. Display a product with some details
+2. Allow you to indicate that you want to purchase it by "adding" it to your "cart"
+3. Allow you to manage your "cart"
+4. Present you the cart, with any additional fees, for purchasing
+5. Collect your address and payment information
+6. Charge your credit card
 
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
-Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
+## API
 
-## Learn more
+### Products
 
-  * Official website: https://www.phoenixframework.org/
-  * Guides: https://hexdocs.pm/phoenix/overview.html
-  * Docs: https://hexdocs.pm/phoenix
-  * Forum: https://elixirforum.com/c/phoenix-forum
-  * Source: https://github.com/phoenixframework/phoenix
+We don't want to complicate this too much but we really want to be able to see a list of categories of products and then a list of products in that category.  Also, we should be able to see a specific product.
+
+ - `GET /categories`                  <- shows a list of categories
+ - `GET /categories/{category}`       <- shows a list of products for that category
+ - `GET /products/{product}`         <- shows detail of a given product
+
+### Cart
+
+You can add products to the cart, update product quantity in the cart, delete products from the cart and list the cart contents and total
+
+* `GET /cart`    <- shows cart with total/status/etc
+* `POST /cart`   <- add product to cart (creates cart if not created)
+* `PUT /cart`    <- update product in cart (delete)
+
+### Checkout
+
+For checkout, you'll be shown the cart total/items and then enter your shipping address and billing information
+
+ * `GET /checkout` <- show cart with address information
+ * `POST /checkout` <- process checkout and redirect to order
+
+### Order
+
+ * `GET /orders/{order}` <- show order details and status
+ * `GET /orders`         <- show all orders
+
+## DB Schema
+
+### Categories &
+* uuid
+* name
+* timestamps
+
+### Orders &
+* uuid
+* sub_total
+* shipping_cost
+* total
+* user_id
+* status
+* order_date
+* order_ip
+* timestamps
+
+### OrderProducts &
+> holds information about the products in an order
+
+* uuid
+* order_id
+* product_id
+* sku
+* name
+* description
+* price
+* quantity
+* subtotal
+* timestamps
+
+### OrderStatusHistories
+> holds information about the changes in statii for an order
+
+* uuid
+* order_uuid
+* previous_status
+* new_status
+* notes
+* timestamps
+
+### Products &
+* uuid
+* sku
+* name
+* description
+* regular_price
+* discounted_price
+* stock_quantity
+* lead_time
+* timestamps
+
+### ProductCategories &
+> xref between products and categories - a category "has many" products and a product can "belong to" many categories
+
+* id
+* category_uuid
+* product_uuid
+* timestamps
+
+### ProductImages &
+* uuid
+* product_uuid
+* image_url
+* default
+* timestamps
+
+### ProductTags &
+* uuid
+* product_uuid
+* tag_uuid
+* timestamps
+### Tags &
+* uuid
+* tag
+* timestamps
+
+### Users &
+* uuid
+* email
+* encrypted_password
+* first_name
+* last_name
+* one_time_signin_token
+* one_time_signin_token_sent_at
+* sign_in_count
+* current_sign_in_at
+* last_sign_in_at
+* current_sign_in_ip
+* last_sign_in_ip
+* failed_attempts
+* locked_at
+* timestamps
+
+### UserSocialCredentials &
+* uuid
+* user_uuid
+* provider
+* provider_user_id
+* provider_details
+* timestamps

--- a/lib/ex_cosmic/product.ex
+++ b/lib/ex_cosmic/product.ex
@@ -1,0 +1,26 @@
+defmodule ExCosmic.Product do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "products" do
+    field :description, :string
+    field :discounted_price, :float
+    field :lead_time, :integer
+    field :name, :string
+    field :regular_price, :float
+    field :sku, :string
+    field :stock_quantity, :integer
+    field :uuid, Ecto.UUID
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(product, attrs) do
+    product
+    |> cast(attrs, [:uuid, :sku, :name, :description, :regular_price, :discounted_price, :stock_quantity, :lead_time])
+    |> validate_required([:uuid, :sku, :name, :description, :regular_price, :discounted_price, :stock_quantity, :lead_time])
+  end
+end

--- a/priv/repo/migrations/20210307210426_create_products.exs
+++ b/priv/repo/migrations/20210307210426_create_products.exs
@@ -1,0 +1,20 @@
+defmodule ExCosmic.Repo.Migrations.CreateProducts do
+  use Ecto.Migration
+
+  def change do
+    create table(:products, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :uuid, :uuid
+      add :sku, :string
+      add :name, :string
+      add :description, :string
+      add :regular_price, :float
+      add :discounted_price, :float
+      add :stock_quantity, :integer
+      add :lead_time, :integer
+
+      timestamps()
+    end
+
+  end
+end

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -1,0 +1,72 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 12.5
+-- Dumped by pg_dump version 12.5
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: products; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.products (
+    id uuid NOT NULL,
+    uuid uuid,
+    sku character varying(255),
+    name character varying(255),
+    description character varying(255),
+    regular_price double precision,
+    discounted_price double precision,
+    stock_quantity integer,
+    lead_time integer,
+    inserted_at timestamp(0) without time zone NOT NULL,
+    updated_at timestamp(0) without time zone NOT NULL
+);
+
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_migrations (
+    version bigint NOT NULL,
+    inserted_at timestamp(0) without time zone
+);
+
+
+--
+-- Name: products products_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products
+    ADD CONSTRAINT products_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+INSERT INTO public."schema_migrations" (version) VALUES (20210307210426);


### PR DESCRIPTION
This uses mix and ecto to make a new schema

```bash
 mix phx.gen.schema Product products uuid:uuid sku:string name:string description:string regular_price:float discounted_price:float stock_quantity:integer lead_time:integer
* creating lib/ex_cosmic/product.ex
* creating priv/repo/migrations/20210307210426_create_products.exs

Remember to update your repository by running migrations:

    $ mix ecto.migrate

➜  ex_cosmic git:(main) ✗ mix ecto.migrate
Compiling 1 file (.ex)
Generated ex_cosmic app

16:04:44.838 [info]  == Running 20210307210426 ExCosmic.Repo.Migrations.CreateProducts.change/0 forward

16:04:44.842 [info]  create table products

16:04:44.855 [info]  == Migrated 20210307210426 in 0.0s
➜  ex_cosmic git:(main) ✗ mix ecto.dump
The structure for ExCosmic.Repo has been dumped to /Users/patrickveverka/Code/personal/ex_cosmic/priv/repo/structure.sql
```